### PR TITLE
Dehydrated

### DIFF
--- a/nethserver-letsencrypt.spec
+++ b/nethserver-letsencrypt.spec
@@ -11,7 +11,7 @@ BuildRequires: nethserver-devtools >= 1.1.0-5
 
 AutoReq: no
 Requires: nethserver-base, nethserver-httpd
-Requires: letsencrypt.sh
+Requires: dehydrated
 
 
 %description

--- a/nethserver-letsencrypt.spec
+++ b/nethserver-letsencrypt.spec
@@ -30,6 +30,7 @@ rm -rf $RPM_BUILD_ROOT
 (cd root   ; find . -depth -print | cpio -dump $RPM_BUILD_ROOT)
 %{genfilelist} $RPM_BUILD_ROOT > %{name}-%{version}-filelist
 mkdir -p %{buildroot}/var/www/html/.well-known/acme-challenge/ 
+mkdir -p %{buildroot}/etc/letsencrypt.sh/certs/
 echo "%doc COPYING" >> %{name}-%{version}-filelist
 
 %clean 
@@ -38,6 +39,8 @@ rm -rf $RPM_BUILD_ROOT
 %files -f %{name}-%{version}-filelist
 %defattr(-,root,root)
 %dir /var/www/html/.well-known/acme-challenge/
+%dir /etc/letsencrypt.sh/
+%dir /etc/letsencrypt.sh/certs/
 
 %changelog
 * Wed Mar 29 2017 Giacomo Sanchietti <giacomo.sanchietti@nethesis.it> - 1.0.4-1

--- a/nethserver-letsencrypt.spec
+++ b/nethserver-letsencrypt.spec
@@ -12,6 +12,7 @@ BuildRequires: nethserver-devtools >= 1.1.0-5
 AutoReq: no
 Requires: nethserver-base, nethserver-httpd
 Requires: dehydrated
+Obsoletes: letsencrypt.sh
 
 
 %description

--- a/root/usr/libexec/nethserver/letsencrypt-certs
+++ b/root/usr/libexec/nethserver/letsencrypt-certs
@@ -10,7 +10,7 @@ my $cdb = esmith::ConfigDB->open();
 my $ddb = esmith::HostsDB->open_ro();
 
 my $crtdir = "/etc/letsencrypt.sh/certs/";
-my $lebin = "/usr/sbin/letsencrypt.sh";
+my $lebin = "/usr/bin/dehydrated";
 my $config = "/etc/letsencrypt.sh/config.sh";
 my $verbose = 0;
 my $testing = 0;
@@ -20,7 +20,7 @@ our $modified = 0;
 sub renew {
     my $domains = shift;
 
-    my $opts = "--cron  --config $config ";
+    my $opts = "--accept-terms --cron  --config $config ";
 
     # file paths
     my $crt = $crtdir.${$domains}[0]."/cert.pem";


### PR DESCRIPTION
Old (un-mantained) letsencrypt.sh client doesn't work anymore because Let's Encrypt
changed the URL of terms of service.

This PR switch from old `letsencrypt.sh` RPM built by us, to latest `dehydrated` package from EPEL.
