### PR TITLE
helper: force lowercase for domain

### DIFF
--- a/root/usr/libexec/nethserver/letsencrypt-certs
+++ b/root/usr/libexec/nethserver/letsencrypt-certs
@@ -46,7 +46,7 @@ sub renew {
     }
 
     # file paths
-    my $crt = $crtdir."/live/".${$domains}[0]."/cert.pem";
+    my $crt = $crtdir."/live/".lc(${$domains}[0])."/cert.pem";
     
     # read the date of certificate link before renewal
     my $tmp = stat($crt);


### PR DESCRIPTION
Permit execution of certificate-update event when

- the FQDN is mixed case
- the FQDN s not the first entry in the LetsEncryptDomains prop

Thanks to @LotusGuy

NethServer/dev#5441
